### PR TITLE
add:画面遷移図の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,15 @@
 ある日「溝上さんって(営業していて)舐められやすいじゃないですか〜^^」
 と言われたことがありました。「誰にでも優しいってゆう意味ですよ//」とフォローはされましたが、確かに時には自身の意見を貫き通すために”舐められない”という要素は必要だと考えさせられました。
 そこで同じように人から舐められやすいかも？と感じている方向けに、睨みを効かせる相手にも動揺せず、負けずと睨み返すくらいの強い心を養えるサービスを作りたいと思いました。
+
+<br>
+
+## ■画面遷移図
+https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1
+[![Image from Gyazo](https://i.gyazo.com/f2d7ca9b011ef2c6692bbb907e815d6a.png)](https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1)
+
+- ユーザー(User)画面  
+診断判定のみの実装ではTOPページと、Resultページのみにしました。
+
+- 管理者（Adomin）画面  
+利用状況を分析するためのページです。

--- a/README.md
+++ b/README.md
@@ -91,3 +91,11 @@ https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1
 - 管理者（Adomin）画面  
   - 利用状況を分析する用のページ（Top）
   - 仮想ユーザーを作成、編集する用のページ遷移
+
+（補足追加）
+- ユーザー編集画面で登録した写真のシェアONOFFの機能を追加
+- 100人切り達成するとユーザー登録した画像がそのまま殿堂入り写真として反映  
+（※写真を変更する場合は戦績がリセット）
+- 非表示設定もユーザー編集画面が可能
+
+[![Image from Gyazo](https://i.gyazo.com/566e1399720401290c2edbdc3acb25f4.png)](https://gyazo.com/566e1399720401290c2edbdc3acb25f4)

--- a/README.md
+++ b/README.md
@@ -80,10 +80,14 @@
 
 ## ■画面遷移図
 https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1
-[![Image from Gyazo](https://i.gyazo.com/f2d7ca9b011ef2c6692bbb907e815d6a.png)](https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1)
+[![Image from Gyazo](https://i.gyazo.com/813b42566280c670ba5cd71f2d9e2d88.png)](https://gyazo.com/813b42566280c670ba5cd71f2d9e2d88)
 
 - ユーザー(User)画面  
-診断判定のみの実装ではTOPページと、Resultページのみにしました。
+  - 基本の診断用のページ遷移
+  - テーマ別練習用のページ遷移（Traning）
+  - 100人切りチャレンジ用のページ遷移（Challenge）
+  - ログイン後の他ユーザー挑戦用のページ遷移（login）
 
 - 管理者（Adomin）画面  
-利用状況を分析するためのページです。
+  - 利用状況を分析する用のページ（Top）
+  - 仮想ユーザーを作成、編集する用のページ遷移


### PR DESCRIPTION
お疲れ様です！
READMEに以下画面遷移図情報を追加しました。
ご指摘、アドバイス頂ければ幸いです、よろしくお願い致します！

## ■画面遷移図
https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1
[![Image from Gyazo](https://i.gyazo.com/f2d7ca9b011ef2c6692bbb907e815d6a.png)](https://www.figma.com/file/BvZhStLAINqU1i3AnlYgRf/gantobashi?node-id=0%3A1)

- ユーザー(User)画面  
診断判定のみの実装ではTOPページと、Resultページのみにしました。

- 管理者（Adomin）画面  
利用状況を分析するためのページです。